### PR TITLE
Changed the allocation of the shared buffer of type IntBuffer from us…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # FireEffect
 Demonstrates high performance pixel based fire and flames effect in JavaFX.
+
+
+java --module-path ${PATH_TO_FX} --add-modules javafx.controls fireeffect.FireEffectPixelBuffer

--- a/src/fireeffect/FireEffectPixelBuffer.java
+++ b/src/fireeffect/FireEffectPixelBuffer.java
@@ -21,7 +21,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
-import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.Random;
 
@@ -102,7 +101,7 @@ public class FireEffectPixelBuffer extends Application {
         int[] fire = new int[screenHeight * screenWidth];  //this buffer will contain the fire
 
         // new way to store image Shared pixel buffer.
-        IntBuffer intBuffer = ByteBuffer.allocateDirect(4 * screenWidth * screenHeight).asIntBuffer();
+        IntBuffer intBuffer = IntBuffer.allocate(screenWidth * screenHeight);
         PixelFormat<IntBuffer> pixelFormat = PixelFormat.getIntArgbPreInstance();
         PixelBuffer<IntBuffer> pixelBuffer = new PixelBuffer<>(screenWidth, screenHeight, intBuffer, pixelFormat);
 


### PR DESCRIPTION
…ing a directAllocate() to an allocate() call. This avoids having to add -Dprism.order=sw when running the example. The previous version was testing on vs off heap memory usage.